### PR TITLE
Checking if extension is already loaded into the app container before loading it.

### DIFF
--- a/src/FranMoreno/Silex/Provider/PagerfantaServiceProvider.php
+++ b/src/FranMoreno/Silex/Provider/PagerfantaServiceProvider.php
@@ -44,7 +44,9 @@ class PagerfantaServiceProvider implements ServiceProviderInterface
 
         if (isset($app['twig'])) {
             $app->extend('twig', function($twig, $app) {
-                $twig->addExtension(new PagerfantaExtension($app));
+                if (isset($app['pagerfanta'])) {
+                    $twig->addExtension(new PagerfantaExtension($app));
+                }
 
                 return $twig;
             });


### PR DESCRIPTION
This is needed when you want to use middleware (ie. prerender some debug template before action) with some twig part inside. 

Original TwigServiceProvider is using this method for other extensions like security or url_generator.
