### PR TITLE
Handle if extension is already loaded when rendering multiple views

### DIFF
--- a/src/FranMoreno/Silex/Provider/PagerfantaServiceProvider.php
+++ b/src/FranMoreno/Silex/Provider/PagerfantaServiceProvider.php
@@ -47,7 +47,10 @@ class PagerfantaServiceProvider implements ServiceProviderInterface
 
         if (isset($app['twig'])) {
             $app->extend('twig', function($twig, $app) {
-                $twig->addExtension(new PagerfantaExtension($app));
+                $ext = new PagerfantaExtension($app);
+                if(!$twig->hasExtension($ext->getName())) {
+                   $twig->addExtension($ext);
+                }
 
                 return $twig;
             });


### PR DESCRIPTION
When rendering multiple twig file in the same "controller"  a LogicException is throw , you need to test if the extension il already loaded before add it
